### PR TITLE
Fix pressure compensation calculation typo

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -16,5 +16,6 @@
     "testFiles": [
         "tests.ts"
     ],
-    "public": true
+    "public": true,
+    "installedVersion": "workspace:f4dd5301-c17a-4868-152d-497caf8426fb"
 }

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weatherbit",
-    "version": "0.0.13",
+    "version": "0.0.12",
     "description": "SparkFun weatherbit",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -16,6 +16,5 @@
     "testFiles": [
         "tests.ts"
     ],
-    "public": true,
-    "installedVersion": "workspace:f4dd5301-c17a-4868-152d-497caf8426fb"
+    "public": true
 }

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weatherbit",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "SparkFun weatherbit",
     "license": "MIT",
     "dependencies": {

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -171,7 +171,7 @@ namespace weatherbit {
         memcpy((uint8_t *) &digP9, ptr + 16, 2);
 
         // Do the compensation
-        int64_t firstConv = ((int64_t) tFine) - 12800;
+        int64_t firstConv = ((int64_t) tFine) - 128000;
         int64_t secondConv = firstConv * firstConv * (int64_t)digP6;
         secondConv = secondConv + ((firstConv*(int64_t)digP5)<<17);
         secondConv = secondConv + (((int64_t)digP4)<<35);


### PR DESCRIPTION
Fix a typo in the pressure compensation calculation.

https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280-DS002.pdf page 25 shows 128000. Changing 12800 to 128000 changes the result from 1032 hPa to 995 hPa, which is close to my phone (992.7), a Honeywell MPRLS (993) and a dedicated weather station (995.6).