### PR TITLE
Workaround to ensure that the pin objects P12 and P13 are properly initiated.

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weatherbit",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "SparkFun weatherbit",
     "license": "MIT",
     "dependencies": {

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -166,7 +166,7 @@ namespace weatherbit {
         memcpy((uint8_t *) &digP2, ptr + 2, 2);
         memcpy((uint8_t *) &digP3, ptr + 4, 2);
         memcpy((uint8_t *) &digP4, ptr + 6, 2);
-        memcpy((uint8h_t *) &digP5, ptr + 8, 2);
+        memcpy((uint8_t *) &digP5, ptr + 8, 2);
         memcpy((uint8_t *) &digP6, ptr + 10, 2);
         memcpy((uint8_t *) &digP7, ptr + 12, 2);
         memcpy((uint8_t *) &digP8, ptr + 14, 2);

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -171,7 +171,7 @@ namespace weatherbit {
         memcpy((uint8_t *) &digP9, ptr + 16, 2);
 
         // Do the compensation
-        int64_t firstConv = ((int64_t) tFine) - 12800;
+        int64_t firstConv = ((int64_t) tFine) - 128000;
         int64_t secondConv = firstConv * firstConv * (int64_t)digP6;
         secondConv = secondConv + ((firstConv*(int64_t)digP5)<<17);
         secondConv = secondConv + (((int64_t)digP4)<<35);

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -173,7 +173,7 @@ namespace weatherbit {
         memcpy((uint8_t *) &digP9, ptr + 16, 2);
 
         // Do the compensation
-        int64_t firstConv = ((int64_t) tFine) - 128000;
+        int64_t firstConv = ((int64_t) tFine) - 12800;
         int64_t secondConv = firstConv * firstConv * (int64_t)digP6;
         secondConv = secondConv + ((firstConv*(int64_t)digP5)<<17);
         secondConv = secondConv + (((int64_t)digP4)<<35);

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -28,6 +28,8 @@ using namespace pxt;
 #endif
 
 namespace weatherbit {
+
+    // Creating new MicroBitPin objects, because uBit.io.P12 and uBit.io.P13 are not always properly initiated.
     MicroBitPin P12(MICROBIT_ID_IO_P12, MICROBIT_PIN_P12, PIN_CAPABILITY_DIGITAL); 
     MicroBitPin P13(MICROBIT_ID_IO_P13, MICROBIT_PIN_P13, PIN_CAPABILITY_DIGITAL); 
 
@@ -164,7 +166,7 @@ namespace weatherbit {
         memcpy((uint8_t *) &digP2, ptr + 2, 2);
         memcpy((uint8_t *) &digP3, ptr + 4, 2);
         memcpy((uint8_t *) &digP4, ptr + 6, 2);
-        memcpy((uint8_t *) &digP5, ptr + 8, 2);
+        memcpy((uint8h_t *) &digP5, ptr + 8, 2);
         memcpy((uint8_t *) &digP6, ptr + 10, 2);
         memcpy((uint8_t *) &digP7, ptr + 12, 2);
         memcpy((uint8_t *) &digP8, ptr + 14, 2);

--- a/weatherbit.cpp
+++ b/weatherbit.cpp
@@ -28,8 +28,8 @@ using namespace pxt;
 #endif
 
 namespace weatherbit {
-    MicroBitPin P12 = uBit.io.P12;
-    MicroBitPin P13 = uBit.io.P13;
+    MicroBitPin P12(MICROBIT_ID_IO_P12, MICROBIT_PIN_P12, PIN_CAPABILITY_DIGITAL); 
+    MicroBitPin P13(MICROBIT_ID_IO_P13, MICROBIT_PIN_P13, PIN_CAPABILITY_DIGITAL); 
 
     uint8_t init() {
         P12.setDigitalValue(0);


### PR DESCRIPTION
Sometimes uBit.io.P12 and uBit.io.P13 are not properly initiated.
Therefore new MicroBitPin objects are created.
