### PR TITLE
Jacdac Extension

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{"arrowParens":"avoid","semi":false,"tabWidth":4}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch MakeCode",
+            "program": "mkc",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${file}",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/built/**/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,36 +1,67 @@
 
 // A task runner that calls the PXT compiler and
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // The command is pxt. Assumes that PXT has been installed using npm install -g pxt
     "command": "pxt",
 
-    // The command is a shell script
-    "isShellCommand": true,
-
-    // Show the output window always.
-    "showOutput": "always",
-
-    "tasks": [{
-        "taskName": "deploy",
-        "isBuildCommand": true,
-        "problemMatcher": "$tsc",
-        "args": [""]
-    }, {
-        "taskName": "build",
-        "isTestCommand": true,
-        "problemMatcher": "$tsc",
-        "args": [""]
-    }, {
-        "taskName": "clean",
-        "isTestCommand": true,
-        "problemMatcher": "$tsc",
-        "args": [""]
-    }, {
-        "taskName": "serial",
-        "isTestCommand": true,
-        "problemMatcher": "$tsc",
-        "args": [""]
-    }]
+    "tasks": [
+        {
+            "label": "deploy",
+            "type": "shell",
+            "command": "pxt",
+            "args": [
+                "deploy",
+                ""
+            ],
+            "problemMatcher": "$tsc",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "pxt",
+            "args": [
+                "build",
+                ""
+            ],
+            "problemMatcher": "$tsc",
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "pxt",
+            "args": [
+                "clean",
+                ""
+            ],
+            "problemMatcher": "$tsc",
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "serial",
+            "type": "shell",
+            "command": "pxt",
+            "args": [
+                "serial",
+                ""
+            ],
+            "problemMatcher": "$tsc",
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,0 +1,1 @@
+# Weather:bit Jacdac Extension

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -18,8 +18,8 @@ namespace modules {
 }
 
 namespace servers {
-    jacdac.productIdentifier = 0x36dccd5c
     function start() {
+        jacdac.productIdentifier = 0x36dccd5c
         jacdac.startSelfServers(() => {
             const servers: jacdac.Server[] = [
                 jacdac.createSimpleSensorServer(

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -1,0 +1,52 @@
+//% deprecated
+namespace weatherbit {}
+
+namespace servers {
+    function startServers() {
+        if (!jacdac.isSimulator()) {
+            weatherbit.startRainMonitoring()
+            weatherbit.startWindMonitoring()
+            const servers: jacdac.Server[] = [
+                jacdac.createSimpleSensorServer(
+                    "rain gauge",
+                    jacdac.SRV_RAIN_GAUGE,
+                    "u16.16",
+                    () => weatherbit.rain() / 25.4, // inches -> mm
+                    {
+                        streamingInterval: 30000,
+                        readingError: () => 25.4,
+                    }
+                ),
+                jacdac.createSimpleSensorServer(
+                    "wind speed",
+                    jacdac.SRV_WIND_SPEED,
+                    "u16.16",
+                    () => weatherbit.windSpeed() * 1.60934,
+                    {
+                        streamingInterval: 2000,
+                        readingError: () => 3,
+                    }
+                ),
+            ]
+            for (const server of servers) server.start()
+        }
+        if (jacdac.checkProxy()) jacdac.proxyFinalize()
+    }
+    startServers()
+}
+
+namespace modules {
+    /**
+     * Rain gauge from the weather:bit
+     */
+    //% fixedInstance whenUsed block="weatherbit rain"
+    export const weatherbitRain = new modules.RainGaugeClient(
+        "weatherbit rain?device=self"
+    )
+
+    /**
+     * Wind speed from weather:bit
+     */
+    //% fixedInstance whenUsed block="weatherbit wind speed"
+    export const weatherbitWindSpeed = new modules.WindSpeedClient("weatherbit wind speed?device=self")
+}

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -20,8 +20,6 @@ namespace modules {
 namespace servers {
     function start() {
         jacdac.startSelfServers(() => {
-            weatherbit.startRainMonitoring()
-            weatherbit.startWindMonitoring()
             const servers: jacdac.Server[] = [
                 jacdac.createSimpleSensorServer(
                     jacdac.SRV_RAIN_GAUGE,
@@ -30,6 +28,7 @@ namespace servers {
                     {
                         streamingInterval: 30000,
                         readingError: () => 25.4,
+                        statusCode: jacdac.SystemStatusCodes.Initializing
                     }
                 ),
                 jacdac.createSimpleSensorServer(
@@ -39,9 +38,20 @@ namespace servers {
                     {
                         streamingInterval: 2000,
                         readingError: () => 3,
+                        statusCode: jacdac.SystemStatusCodes.Initializing
                     }
                 ),
             ]
+
+            // booting
+            control.inBackground(() => {
+                weatherbit.startRainMonitoring()
+                weatherbit.startWindMonitoring()
+                for(const server of servers)
+                    server.setStatusCode(jacdac.SystemStatusCodes.Ready)
+            })
+
+            // return servers
             return servers
         })
     }

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -7,14 +7,14 @@ namespace modules {
      */
     //% fixedInstance whenUsed block="weatherbit rain"
     export const weatherbitRain = new modules.RainGaugeClient(
-        "weatherbit rain?device=self"
+        "weatherbit rain?dev=self"
     )
 
     /**
      * Wind speed from weather:bit
      */
     //% fixedInstance whenUsed block="weatherbit wind speed"
-    export const weatherbitWindSpeed = new modules.WindSpeedClient("weatherbit wind speed?device=self")
+    export const weatherbitWindSpeed = new modules.WindSpeedClient("weatherbit wind speed?dev=self")
 }
 
 namespace servers {

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -18,6 +18,7 @@ namespace modules {
 }
 
 namespace servers {
+    jacdac.productIdentifier = 0x36dccd5c
     function start() {
         jacdac.startSelfServers(() => {
             const servers: jacdac.Server[] = [

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -1,39 +1,5 @@
 //% deprecated
-namespace weatherbit {}
-
-namespace servers {
-    function startServers() {
-        if (!jacdac.isSimulator()) {
-            weatherbit.startRainMonitoring()
-            weatherbit.startWindMonitoring()
-            const servers: jacdac.Server[] = [
-                jacdac.createSimpleSensorServer(
-                    "rain gauge",
-                    jacdac.SRV_RAIN_GAUGE,
-                    "u16.16",
-                    () => weatherbit.rain() / 25.4, // inches -> mm
-                    {
-                        streamingInterval: 30000,
-                        readingError: () => 25.4,
-                    }
-                ),
-                jacdac.createSimpleSensorServer(
-                    "wind speed",
-                    jacdac.SRV_WIND_SPEED,
-                    "u16.16",
-                    () => weatherbit.windSpeed() * 1.60934,
-                    {
-                        streamingInterval: 2000,
-                        readingError: () => 3,
-                    }
-                ),
-            ]
-            for (const server of servers) server.start()
-        }
-        if (jacdac.checkProxy()) jacdac.proxyFinalize()
-    }
-    startServers()
-}
+namespace weatherbit { }
 
 namespace modules {
     /**
@@ -49,4 +15,35 @@ namespace modules {
      */
     //% fixedInstance whenUsed block="weatherbit wind speed"
     export const weatherbitWindSpeed = new modules.WindSpeedClient("weatherbit wind speed?device=self")
+}
+
+namespace servers {
+    function start() {
+        jacdac.startSelfServers(() => {
+            weatherbit.startRainMonitoring()
+            weatherbit.startWindMonitoring()
+            const servers: jacdac.Server[] = [
+                jacdac.createSimpleSensorServer(
+                    jacdac.SRV_RAIN_GAUGE,
+                    jacdac.RainGaugeRegPack.Precipitation,
+                    () => weatherbit.rain() / 25.4, // inches -> mm
+                    {
+                        streamingInterval: 30000,
+                        readingError: () => 25.4,
+                    }
+                ),
+                jacdac.createSimpleSensorServer(
+                    jacdac.SRV_WIND_SPEED,
+                    jacdac.WindSpeedRegPack.WindSpeed,
+                    () => weatherbit.windSpeed() * 1.60934,
+                    {
+                        streamingInterval: 2000,
+                        readingError: () => 3,
+                    }
+                ),
+            ]
+            return servers
+        })
+    }
+    start()
 }

--- a/jacdac/jacdac.ts
+++ b/jacdac/jacdac.ts
@@ -20,6 +20,7 @@ namespace modules {
 namespace servers {
     function start() {
         jacdac.productIdentifier = 0x36dccd5c
+        jacdac.deviceDescription = "Sparkfun Weather:bit"
         jacdac.startSelfServers(() => {
             const servers: jacdac.Server[] = [
                 jacdac.createSimpleSensorServer(

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.27",
+    "version": "0.0.28",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.23",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.23"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.27",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.27"
     },
     "files": [
         "README.md",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,14 +1,14 @@
 {
-    "name": "jacdac-weather-bit",
+    "name": "weather-bit-jacdac",
     "version": "0.0.20",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.9.3",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.9.3",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.9.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.3",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.3"
     },
     "files": [
         "README.md",
@@ -19,7 +19,7 @@
     ],
     "public": true,
     "targetVersions": {
-        "target": "4.0.18",
+        "target": "4.1.24",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.5",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.5"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.14",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.14"
     },
     "files": [
         "README.md",
@@ -19,7 +19,7 @@
     ],
     "public": true,
     "targetVersions": {
-        "target": "4.1.24",
+        "target": "4.1.27",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.24",
+    "version": "0.0.25",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "jacdac-weather-bit",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.14",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.14"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.23",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.23"
     },
     "files": [
         "README.md",
@@ -19,7 +19,7 @@
     ],
     "public": true,
     "targetVersions": {
-        "target": "4.1.27",
+        "target": "4.1.30",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "weatherbit": "github:sparkfun/pxt-weather-bit",
+        "pxt-weather-bit": "github:sparkfun/pxt-weather-bit",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
         "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.27",
         "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.27"

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.3",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.5",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.5"
     },
     "files": [
         "README.md",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.20",
+    "version": "0.0.21",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,7 +6,9 @@
     "dependencies": {
         "core": "*",
         "weatherbit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.9.3",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.9.3",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.9.3"
     },
     "files": [
         "README.md",
@@ -15,5 +17,13 @@
     "testFiles": [
         "tests.ts"
     ],
-    "public": true
+    "public": true,
+    "targetVersions": {
+        "target": "4.0.18",
+        "targetId": "microbit"
+    },
+    "supportedTargets": [
+        "microbit"
+    ],
+    "preferredEditor": "tsprj"
 }

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "core": "*",
         "pxt-weather-bit": "github:sparkfun/pxt-weather-bit",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.27",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.27"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.41",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed#v0.10.41",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge#v0.10.41"
     },
     "files": [
         "README.md",
@@ -19,7 +19,7 @@
     ],
     "public": true,
     "targetVersions": {
-        "target": "4.1.30",
+        "target": "4.1.44",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,0 +1,19 @@
+{
+    "name": "jacdac-weather-bit",
+    "version": "0.0.19",
+    "description": "SparkFun weatherbit Jacdac",
+    "license": "MIT",
+    "dependencies": {
+        "core": "*",
+        "weatherbit": "github:sparkfun/pxt-weather-bit",
+        "jacdac": "github:microsoft/pxt-jacdac"
+    },
+    "files": [
+        "README.md",
+        "jacdac.ts"
+    ],
+    "testFiles": [
+        "tests.ts"
+    ],
+    "public": true
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "weather-bit-jacdac",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "SparkFun weatherbit Jacdac",
     "license": "MIT",
     "dependencies": {

--- a/jacdac/tests.ts
+++ b/jacdac/tests.ts
@@ -1,5 +1,5 @@
 forever(() => {
     console.logValue("rain", modules.weatherbitRain.precipitation())
-    console.logValue("wind speed", modules.weatherbitWindSpeed.windSpeed())    
-    pause(5000)
+    console.logValue("wind", modules.weatherbitWindSpeed.windSpeed())    
+    pause(1000)
 })

--- a/jacdac/tests.ts
+++ b/jacdac/tests.ts
@@ -1,0 +1,5 @@
+forever(() => {
+    console.logValue("rain", modules.weatherbitRain.precipitation())
+    console.logValue("wind speed", modules.weatherbitWindSpeed.windSpeed())    
+    pause(5000)
+})

--- a/mkc.json
+++ b/mkc.json
@@ -1,0 +1,9 @@
+{
+    "links": {
+        "weatherbit": "."
+    },
+    "targetWebsite": "https://makecode.microbit.org/beta",
+    "overrides": {
+        "testDependencies": {}
+    }
+}

--- a/mkc.json
+++ b/mkc.json
@@ -1,9 +1,0 @@
-{
-    "links": {
-        "weatherbit": "."
-    },
-    "targetWebsite": "https://makecode.microbit.org/beta",
-    "overrides": {
-        "testDependencies": {}
-    }
-}

--- a/pxt.json
+++ b/pxt.json
@@ -4,7 +4,9 @@
     "description": "SparkFun weatherbit",
     "license": "MIT",
     "dependencies": {
-        "core": "*"
+        "core": "*",
+        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge",
+        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed"
     },
     "files": [
         "README.md",

--- a/pxt.json
+++ b/pxt.json
@@ -4,9 +4,7 @@
     "description": "SparkFun weatherbit",
     "license": "MIT",
     "dependencies": {
-        "core": "*",
-        "jacdac-rain-gauge": "github:microsoft/pxt-jacdac/rain-gauge",
-        "jacdac-wind-speed": "github:microsoft/pxt-jacdac/wind-speed"
+        "core": "*"
     },
     "files": [
         "README.md",


### PR DESCRIPTION
This pull requests add support for Jacdac for this accessory which allows users to use simulators in MakeCode. Jacdac support will be released in the next major release of MakeCode for micro:bit (summer 2022).

-   This change adds a new nested extension (`jacdac` folder)
and does not modify the existing extension. **Your existing lessons, tutorials and blocks are not impacted by this change.**
-   No hardware modification is required for existing accessories, this feature
is [backward compatible](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/). However, it requires a micro:bit V2 to run.

The benefits for the users and you will be:

-   **Simulator** Jacdac enables simulations of all sensors and actuators
-   **Digital twins** Jacdac surfaces the hardware state directly into the MakeCode editor
-   **Standardized blocks and lessons** the programming will be done through
Jacdac blocks maintained by the Microsoft team

![image](https://user-images.githubusercontent.com/4175913/170539395-f5b0b023-251a-4c20-865b-0f8db61f2cfb.png)

We recommend reading the [Jacdac software only accessory](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/) documentation page to learn more 
about the details of this approach. You can also review a list of similar [software only extensions](https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/).

Please do not hesitate to contact us through this pull request or at jacdac-tap@microsoft.com 
if you have any question or want to schedule a call.

## How to test this extension as a user?

**This features requires to beta editor of MakeCode at https://makecode.microbit.org/beta.**

- Click on https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/
- Find the extension for this accessory
- Click on **Try MakeCode** to open a project that as a user
- Use the blocks from the **Modules** toolbox

You can follow the [micro:bit Jacdac guide](https://microsoft.github.io/jacdac-docs/clients/makecode/) to learn how Jacdac integrates into MakeCode

## TODOs

- [ ] merge this pull request (squash recommended)
- [ ] create a new release for the repository
- [ ] review the accessory page in the [Jacdac device catalog](https://microsoft.github.io/jacdac-docs/devices/) to make sure we got all the details right

Once the pull request is merged, we will update the catalog to point to it rather than our temporary fork.

## Future accessories TODOs

- Review the [micro:bit accessory Jacdac integration guide](https://microsoft.github.io/jacdac-docs/ddk/microbit/) to learn how you can integrate Jacdac into your future accessories for a better user experience. We provide various options to integrate Jacdac into your hardware at minimal cost.
- Review the [Jacdac Device Development Kit](https://microsoft.github.io/jacdac-docs/ddk/) for more details about hardware integration of Jacdac in general.
- Contact us if you have any question about adding Jacdac to your next accessory through [Discussions](https://github.com/microsoft/jacdac/discussions) or at jacdac-tag@microsoft.com.